### PR TITLE
Add "Two Minute Papers" and "Talking Machines"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,7 @@ Find It Here: http://www.mit.edu/~tomeru/papers/machines_that_think.pdf
 
 
 ## YouTube Channels That Deserve Your Subscription
-> Coming Soon...
+*Two Minute Papers* -- https://www.youtube.com/channel/UCbfYPyITQ-7l4upoX8nvctg
+
+## Podcasts
+*Talking Machines* -- Ryan Adams & Katherine Gorman -- http://www.thetalkingmachines.com/


### PR DESCRIPTION
*Two Minute Papers* summarizes recent influential machine learning papers and explains the basics of how they work in 2-5 minutes. His explanations don't usually delve into the math behind any of the papers, but, since the channel is updated around 3 times per week, it's an easy way to get an overview of research you may not have otherwise paid attention to.

*Talking Machines* is the go-to podcast for ML, data science, and the statistical side of AI. Ryan Adams is the director of the Harvard Intelligent Probabilistic Systems group, and sits on the board of a lot of big-name AI conferences. Episodes typically spend 10-15 minutes talking about a topic in ML, then transition to an interview with a researcher.